### PR TITLE
Use adapters to manipulate API response

### DIFF
--- a/lib/quirky-api/configurable.rb
+++ b/lib/quirky-api/configurable.rb
@@ -52,23 +52,28 @@ module QuirkyApi
         @adapters
       end
 
+      # Use a new +adapter+.  This will place your adapter just before the
+      # EnvelopeAdapter, which makes a noticable change by wrapping your data
+      # with a key.
       def use(new_adapter)
         insert_before EnvelopeAdapter, new_adapter
       end
 
+      # Insert your +new_adapter+ just before +adapter+ in the adapter order.
       def insert_before(adapter, new_adapter)
         @adapters << {
-          position: adapter,
-          operation: '-1',
-          adapter: new_adapter
+          adapter: adapter,
+          placement: '-1',
+          new_adapter: new_adapter
         }
       end
 
+      # Inser your +new_adapter+ just after +adapter+ in the adapter order.
       def insert_after(adapter, new_adapter)
         @adapters << {
-          position: adapter,
-          operation: '+1',
-          adapter: new_adapter
+          adapter: adapter,
+          placement: '+1',
+          new_adapter: new_adapter
         }
       end
     end

--- a/lib/quirky-api/configurable.rb
+++ b/lib/quirky-api/configurable.rb
@@ -5,7 +5,7 @@ module QuirkyApi
   class << self
     attr_accessor :validate_associations, :warn_invalid_fields, :auth_system,
                   :show_exceptions, :exception_handler, :envelope,
-                  :pretty_print, :jsonp
+                  :pretty_print, :jsonp, :adapters
 
     def has_auth_system?
       auth_system.present? && auth_system.is_a?(Module)
@@ -27,8 +27,51 @@ module QuirkyApi
       jsonp === true
     end
 
+    def adapters
+      AdapterConfig.instance
+    end
+
     def configure
       yield(self)
     end
+
+    class AdapterConfig
+      include Singleton
+
+      attr_accessor :adapters
+
+      def initialize
+        @adapters ||= []
+      end
+
+      def all
+        @adapters
+      end
+
+      def inspect
+        @adapters
+      end
+
+      def use(new_adapter)
+        insert_before EnvelopeAdapter, new_adapter
+      end
+
+      def insert_before(adapter, new_adapter)
+        @adapters << {
+          position: adapter,
+          operation: '-1',
+          adapter: new_adapter
+        }
+      end
+
+      def insert_after(adapter, new_adapter)
+        @adapters << {
+          position: adapter,
+          operation: '+1',
+          adapter: new_adapter
+        }
+      end
+    end
   end
 end
+

--- a/lib/quirky-api/response.rb
+++ b/lib/quirky-api/response.rb
@@ -2,6 +2,7 @@
 
 require 'quirky-api/response/errors'
 require 'quirky-api/response/pagination'
+require 'quirky-api/response/response_adapter'
 
 module QuirkyApi
   # The response module handles response and status code methods for the API.
@@ -43,11 +44,8 @@ module QuirkyApi
     def respond_with(response, options = {}, &block)
       return if @performed_render
 
-      @api_response_envelope = if options.key?(:envelope)
-                                 options[:envelope]
-                               else
-                                 QuirkyApi.envelope
-                               end
+      # Fallback to default envelope unless we set one on the options.
+      options[:envelope] = QuirkyApi.envelope unless options.key?(:envelope)
 
       if block_given?
         options = response
@@ -87,7 +85,11 @@ module QuirkyApi
       # Make sure we serialize unless otherwise specified.
       options[:serialize] = true if options[:serialize].nil?
 
-      return render(json: envelope(nil)) if response.nil?
+      # If our response variable is nil, just return a null value to save time.
+      return render(prepare_response(nil, options)) if response.nil?
+
+      # Include params in all options sent forth to serializers.
+      options[:params] = params
 
       # If there's an active model serializer to speak of, use it.
       # Otherwise, just render what we've got.
@@ -95,7 +97,6 @@ module QuirkyApi
                 response.try(:active_model_serializer).present? &&
                 options[:serialize] == true
 
-               options[:params] = params
                options[:current_user] = current_user if defined? current_user
 
                serializer = response.active_model_serializer
@@ -103,8 +104,8 @@ module QuirkyApi
                  serializer = QuirkyArraySerializer
                end
 
-               @serialized_data = serializer.new(response, options)
-               @serialized_data.as_json(root: false)
+               options[:serialized_data] = serializer.new(response, options)
+               options[:serialized_data].as_json(root: false)
              else
                response
              end
@@ -117,7 +118,7 @@ module QuirkyApi
             paginated_meta[key] = value.paginated_meta
           end
         end
-        options[:paginated_meta] = {paginated_meta: paginated_meta} unless paginated_meta.empty?
+        options[:paginated_meta] = { paginated_meta: paginated_meta } unless paginated_meta.empty?
       end
 
       renderable = prepare_response(data, options)
@@ -162,59 +163,8 @@ module QuirkyApi
     #   #=> [{ id: 1, name: 'Mike Sea' }, { id: 2, name: 'Bob Tester' }]
     #
     def append_meta(data, options = {})
-      # Allow the envelope to be configurable from within the options.
-      # +options+ here are passed all the way from +respond_with+, so you can
-      # specify the envelope in your endpoint, for example:
-      #
-      # @example
-      #   respond_with User.last, envelope: 'user'
-      #
-      @api_response_envelope = options[:envelope] if options[:envelope].present?
-
-      # Because JSONP responses wrap the response within a function, we append
-      # extra meta information to the response so we get essentially the same
-      # results as if we made a request with AJAX or something.  JSONP
-      # responses *must* be wrapped in an envelope so that the meta information
-      # can be passed forward.
-      #
-      # Using JSONP means that the response will always return 200 (OK), and
-      # you should use the meta 'status' attribute to retrieve the actual
-      # status code.
-      callback = params[:callback].presence || options[:callback]
-      if QuirkyApi.jsonp? && callback.present?
-        # JSONP responses must be wrapped in an envelope so there can be meta information.
-        @api_response_envelope = 'data' if @api_response_envelope.blank?
-        (options[:elements] ||= {}).merge!(meta: { status: options[:status].presence || 200 })
-      end
-
-      # Envelope the data, if applicable.  In the event of a JSONP response,
-      # the data will always be enveloped.
-      data = envelope(data)
-
-      # Further changes would be impossible if the data was not already a hash.
-      return data unless data.is_a?(Hash)
-
-      # Check for warnings if applicable.
-      if QuirkyApi.warn_invalid_fields
-        if @serialized_data.present?
-          warnings = @serialized_data.warnings(params)
-          data[:warnings] = warnings if warnings.present?
-        end
-      end
-
-      # +elements+ are top level keys in the JSON response, appearing at the
-      # same level as the envelope for data.  You can specify as many elements
-      # as you want, so long as they are a hash.
-      data.merge!(options[:elements]) if options[:elements].present?
-
-      # Paginated meta is information returned from our custom implementation
-      # of pagination.
-      data.merge!(options[:paginated_meta]) if options[:paginated_meta].present?
-
-      # If configured, we pretty JSON responses.  This is the default response.
-      data = JSON.pretty_generate(data) if QuirkyApi.pretty_print?
-
-      data
+      @response_adapter = ResponseAdapter.new(data, options)
+      @response_adapter.call!
     end
 
     # <tt>build_json_response</tt> prepares and returns the actual object that
@@ -241,20 +191,8 @@ module QuirkyApi
     #                        will appear.
     #
     def build_json_response(data, options = {})
-      renderable = { json: data }
-
-      # As described above, if this is a JSONP response, we respond 200 (OK)
-      # and specify the callback to +render+.  Otherwise, we use the default
-      # status code.
-      callback = params[:callback].presence || options[:callback]
-      if QuirkyApi.jsonp? && callback.present?
-        renderable[:callback] = callback
-        renderable[:status] = 200
-      else
-        renderable[:status] = options[:status] if options[:status].present?
-      end
-
-      renderable
+      @response_adapter ||= ResponseAdapter.new(data, options)
+      @response_adapter.finalize!(json: data)
     end
 
     # <tt>prepare_data</tt> is the final step before objects are displayed as
@@ -289,8 +227,8 @@ module QuirkyApi
     #
     # @return [Hash] The enveloped data, if applicable.
     def envelope(data)
-      return data if @api_response_envelope.blank?
-      { @api_response_envelope.to_s => data }
+      return data if options.blank?
+      { options.to_s => data }
     end
   end
 end

--- a/lib/quirky-api/response.rb
+++ b/lib/quirky-api/response.rb
@@ -91,6 +91,9 @@ module QuirkyApi
       # Include params in all options sent forth to serializers.
       options[:params] = params
 
+      # Allow us to configure headers in response.
+      options[:headers] = headers
+
       # If there's an active model serializer to speak of, use it.
       # Otherwise, just render what we've got.
       data = if response.respond_to?(:active_model_serializer) &&

--- a/lib/quirky-api/response.rb
+++ b/lib/quirky-api/response.rb
@@ -195,8 +195,8 @@ module QuirkyApi
       @response_adapter.finalize!(json: data)
     end
 
-    # <tt>prepare_data</tt> is the final step before objects are displayed as
-    # JSON in the API.  This method will append warnings, elements and
+    # <tt>prepare_response</tt> is the final step before objects are displayed
+    # as JSON in the API.  This method will append warnings, elements and
     # paginated_data to the response if possible, and 'prettify' the JSON
     # output if configured.
     #
@@ -217,18 +217,6 @@ module QuirkyApi
     def prepare_response(data, options = {})
       data = append_meta(data, options)
       build_json_response(data, options)
-    end
-
-    private
-
-    # Envelopes data based on +QuirkyApi.envelope+.
-    #
-    # @param data [Object] Any type of object.
-    #
-    # @return [Hash] The enveloped data, if applicable.
-    def envelope(data)
-      return data if options.blank?
-      { options.to_s => data }
     end
   end
 end

--- a/lib/quirky-api/response.rb
+++ b/lib/quirky-api/response.rb
@@ -47,6 +47,12 @@ module QuirkyApi
       # Fallback to default envelope unless we set one on the options.
       options[:envelope] = QuirkyApi.envelope unless options.key?(:envelope)
 
+      # Include params in all options sent forth to serializers.
+      options[:params] = params
+
+      # Allow us to configure headers in response.
+      options[:headers] = headers
+
       if block_given?
         options = response
 
@@ -87,12 +93,6 @@ module QuirkyApi
 
       # If our response variable is nil, just return a null value to save time.
       return render(prepare_response(nil, options)) if response.nil?
-
-      # Include params in all options sent forth to serializers.
-      options[:params] = params
-
-      # Allow us to configure headers in response.
-      options[:headers] = headers
 
       # If there's an active model serializer to speak of, use it.
       # Otherwise, just render what we've got.

--- a/lib/quirky-api/response/adapters/api_adapter.rb
+++ b/lib/quirky-api/response/adapters/api_adapter.rb
@@ -34,7 +34,7 @@ class ApiAdapter
 
   def initialize(data, options)
     @data = data
-    @headers = options.fetch(:headers)
+    @headers = options.fetch(:headers, {})
     @options = options
   end
 

--- a/lib/quirky-api/response/adapters/api_adapter.rb
+++ b/lib/quirky-api/response/adapters/api_adapter.rb
@@ -1,0 +1,12 @@
+class ApiAdapter
+  attr_accessor :data, :options
+
+  def initialize(data, options)
+    @data = data
+    @options = options
+  end
+
+  def call
+    raise 'You must implement your own #call method in your subclass.'
+  end
+end

--- a/lib/quirky-api/response/adapters/api_adapter.rb
+++ b/lib/quirky-api/response/adapters/api_adapter.rb
@@ -1,3 +1,34 @@
+##
+# This is a base Adapter class for API response adapters.  It is not necessary,
+# but it does offer access to the +data+ and +options+ attributes in your
+# custom +call+ methods.
+#
+# If you wish, extend ApiAdapter in your custom adapter and create a +call+
+# method, which will be able to manipulate the data that is returned in the
+# JSON response.  The only pre-requisite is that the +call+ method must
+# return a value that can be further altered on its way to proper response.
+#
+# If you want to use a custom adapter, you must ensure it is configured in your
+# +QuirkyApi.configure+ block.  You can use +config.adapters.insert_before+,
+# +config.adapters.insert_after+ or +config.adapters.use+, exactly like you
+# would with Middleware.  Note: By default, +config.adapters.use+ will insert
+# your adapter immediately before the +envelope+ adapter, because +envelope+
+# will mutate the data into a harder-to-modify object.
+#
+# @example
+#   # The below example will show a 'meta' object below the rest of the data,
+#   # with 'status: 418' within it.
+#   class FakeResponseStatusAdapter < ApiAdapter
+#     def call
+#       data[:meta] = { status: 418 }
+#     end
+#   end
+#
+#   # ...in your config file
+#   QuirkyApi.configure do |config|
+#     config.adapters.use FakeResponseStatusAdapter
+#   end
+#
 class ApiAdapter
   attr_accessor :data, :options
 
@@ -6,7 +37,24 @@ class ApiAdapter
     @options = options
   end
 
+  # This is a stub method to show that you can (and should) have a +call+
+  # method in your custom adapter.  The call method is executed for each
+  # configured adapter, and has the ability to mutate response data or
+  # options sent forward to the final response (like status).  This method
+  # must return data that can be further mutated.
   def call
     raise 'You must implement your own #call method in your subclass.'
   end
+
+  # def finalize(renderable)
+  #   # This is just a stub method to show that you can have a +finalize+
+  #   # method in your custom adapter.  The +finalize+ method will be run
+  #   # after data has been mutated, and just before the data is actually
+  #   # rendered to the front-end.
+  #   #
+  #   # Your custom +finalize+ method is sent the +renderable+ hash, which
+  #   # eventually will be passed to +render+ in order to provide the response.
+  #   # Therefore, the result of this should return a Ruby Hash that is
+  #   # understandable by the +render+ method.
+  # end
 end

--- a/lib/quirky-api/response/adapters/api_adapter.rb
+++ b/lib/quirky-api/response/adapters/api_adapter.rb
@@ -30,10 +30,11 @@
 #   end
 #
 class ApiAdapter
-  attr_accessor :data, :options
+  attr_accessor :data, :headers, :options
 
   def initialize(data, options)
     @data = data
+    @headers = options.fetch(:headers)
     @options = options
   end
 

--- a/lib/quirky-api/response/adapters/elements_adapter.rb
+++ b/lib/quirky-api/response/adapters/elements_adapter.rb
@@ -1,0 +1,14 @@
+class ElementsAdapter < ApiAdapter
+  def call
+    return data unless data.is_a?(Hash)
+
+    # +elements+ are top level keys in the JSON response, appearing at the
+    # same level as the envelope for data.  You can specify as many elements
+    # as you want, so long as they are a hash.
+    if options[:elements].present? && options[:elements].is_a?(Hash)
+      data.merge!(options[:elements])
+    end
+
+    data
+  end
+end

--- a/lib/quirky-api/response/adapters/envelope_adapter.rb
+++ b/lib/quirky-api/response/adapters/envelope_adapter.rb
@@ -1,0 +1,19 @@
+class EnvelopeAdapter < ApiAdapter
+  def call
+    # Envelope the data, if applicable.  In the event of a JSONP response,
+    # the data will always be enveloped.
+    envelope(data)
+  end
+
+  private
+
+  # Envelopes data based on +QuirkyApi.envelope+.
+  #
+  # @param data [Object] Any type of object.
+  #
+  # @return [Hash] The enveloped data, if applicable.
+  def envelope(data)
+    return data if options[:envelope].blank?
+    { options[:envelope].to_s => data }
+  end
+end

--- a/lib/quirky-api/response/adapters/jsonp_adapter.rb
+++ b/lib/quirky-api/response/adapters/jsonp_adapter.rb
@@ -1,0 +1,36 @@
+class JsonpAdapter < ApiAdapter
+  def call
+    # Because JSONP responses wrap the response within a function, we append
+    # extra meta information to the response so we get essentially the same
+    # results as if we made a request with AJAX or something.  JSONP
+    # responses *must* be wrapped in an envelope so that the meta information
+    # can be passed forward.
+    #
+    # Using JSONP means that the response will always return 200 (OK), and
+    # you should use the meta 'status' attribute to retrieve the actual
+    # status code.
+    callback = (options[:params].presence && options[:params][:callback].presence) || options[:callback]
+    if QuirkyApi.jsonp? && callback.present?
+      # JSONP responses must be wrapped in an envelope so there can be meta information.
+      options[:envelope] = 'data' if options[:envelope].blank?
+      (options[:elements] ||= {}).merge!(meta: { status: options[:status].presence || 200 })
+    end
+
+    data
+  end
+
+  def finalize(renderable)
+    # As described above, if this is a JSONP response, we respond 200 (OK)
+    # and specify the callback to +render+.  Otherwise, we use the default
+    # status code.
+    callback = (options[:params].presence && options[:params][:callback].presence) || options[:callback]
+    if QuirkyApi.jsonp? && callback.present?
+      renderable[:callback] = callback
+      renderable[:status] = 200
+    else
+      renderable[:status] = options[:status] if options[:status].present?
+    end
+
+    renderable
+  end
+end

--- a/lib/quirky-api/response/adapters/paginated_meta_adapter.rb
+++ b/lib/quirky-api/response/adapters/paginated_meta_adapter.rb
@@ -1,0 +1,13 @@
+class PaginatedMetaAdapter < ApiAdapter
+  def call
+    return data unless data.is_a?(Hash)
+
+    if options[:paginated_meta].present? && options[:paginated_meta].is_a?(Hash)
+      # Paginated meta is information returned from our custom implementation
+      # of pagination.
+      data.merge!(options[:paginated_meta]) if options[:paginated_meta].present?
+    end
+
+    data
+  end
+end

--- a/lib/quirky-api/response/adapters/pretty_print_adapter.rb
+++ b/lib/quirky-api/response/adapters/pretty_print_adapter.rb
@@ -1,0 +1,8 @@
+class PrettyPrintAdapter < ApiAdapter
+  def call
+    return data unless QuirkyApi.pretty_print?
+
+    # If configured, we pretty JSON responses.  This is the default response.
+    JSON.pretty_generate(data)
+  end
+end

--- a/lib/quirky-api/response/adapters/warnings_adapter.rb
+++ b/lib/quirky-api/response/adapters/warnings_adapter.rb
@@ -1,0 +1,12 @@
+class WarningsAdapter < ApiAdapter
+  def call
+    return data unless data.is_a?(Hash)
+    return data unless QuirkyApi.warn_invalid_fields
+    return data unless options[:serialized_data].present?
+
+    warnings = options[:serialized_data].warnings(options[:params])
+    data[:warnings] = warnings if warnings.present?
+
+    data
+  end
+end

--- a/lib/quirky-api/response/response_adapter.rb
+++ b/lib/quirky-api/response/response_adapter.rb
@@ -1,0 +1,71 @@
+module QuirkyApi
+  module Response
+    class ResponseAdapter
+      require File.expand_path('../adapters/api_adapter', __FILE__)
+      require File.expand_path('../adapters/jsonp_adapter', __FILE__)
+      require File.expand_path('../adapters/envelope_adapter', __FILE__)
+      require File.expand_path('../adapters/warnings_adapter', __FILE__)
+      require File.expand_path('../adapters/elements_adapter', __FILE__)
+      require File.expand_path('../adapters/paginated_meta_adapter', __FILE__)
+      require File.expand_path('../adapters/pretty_print_adapter', __FILE__)
+
+      ADAPTERS = [
+        JsonpAdapter,
+        EnvelopeAdapter,
+        WarningsAdapter,
+        ElementsAdapter,
+        PaginatedMetaAdapter,
+        PrettyPrintAdapter
+      ].freeze
+
+      attr_accessor :data, :options
+      attr_accessor :_finalize_adapters
+
+      def initialize(data, options)
+        @data = data
+        @options = options
+        @_finalize_adapters = []
+      end
+
+      def call!
+        configured_adapters.each do |adapter|
+          a = adapter.new(@data, options)
+          @_finalize_adapters << adapter if a.respond_to?(:finalize)
+          @data = a.call
+        end
+
+        @data
+      end
+
+      def finalize!(renderable)
+        @_finalize_adapters.each do |adapter|
+          a = adapter.new(data, options)
+          renderable = a.finalize(renderable)
+        end
+
+        renderable
+      end
+
+      private
+
+      def configured_adapters
+        adapters = ADAPTERS.dup
+
+        QuirkyApi.adapters.all.each do |configured_adapter|
+          case configured_adapter[:operation]
+          when '+1'
+            index = adapters.index(configured_adapter[:position])
+            old_thing = adapters[index]
+            adapters[index, 1] = [old_thing, configured_adapter[:adapter]]
+          when '-1'
+            index = adapters.index(configured_adapter[:position])
+            old_thing = adapters[index]
+            adapters[index, 1] = [configured_adapter[:adapter], old_thing]
+          end
+        end
+
+        adapters
+      end
+    end
+  end
+end

--- a/lib/quirky-api/response/response_adapter.rb
+++ b/lib/quirky-api/response/response_adapter.rb
@@ -1,6 +1,17 @@
+##
+# The ResponseAdapter class handles the mutation, tidying and prettyfing of
+# data before it is rendered in the response.  This class handles everything
+# from JSONP support, to wrapping the data in an "envelope" (e.g. "data"),
+# to pretty priting the final response.
+#
+# While this has a finite list of adapters used directly in the gem, you can
+# easily make your own adapters to further adjust the API response.  See
+# ApiController for further details on custom adapters.
+#
 module QuirkyApi
   module Response
     class ResponseAdapter
+      # Requires files used for base adapters.
       require File.expand_path('../adapters/api_adapter', __FILE__)
       require File.expand_path('../adapters/jsonp_adapter', __FILE__)
       require File.expand_path('../adapters/envelope_adapter', __FILE__)
@@ -9,13 +20,15 @@ module QuirkyApi
       require File.expand_path('../adapters/paginated_meta_adapter', __FILE__)
       require File.expand_path('../adapters/pretty_print_adapter', __FILE__)
 
+      # These are the adapters that Quirky Api uses to tidy and generate our
+      # response.
       ADAPTERS = [
-        JsonpAdapter,
-        EnvelopeAdapter,
-        WarningsAdapter,
-        ElementsAdapter,
-        PaginatedMetaAdapter,
-        PrettyPrintAdapter
+        JsonpAdapter,           # JSONP support.
+        EnvelopeAdapter,        # Envelopes data (e.g.: 'test' becomes { data: 'test' })
+        WarningsAdapter,        # Handles potential warnings due to invalid request fields.
+        ElementsAdapter,        # Handles 'elements', or top-level keys in the JSON response.
+        PaginatedMetaAdapter,   # Handles paginated meta for pagination.
+        PrettyPrintAdapter      # "Prettifies" JSON response.
       ].freeze
 
       attr_accessor :data, :options
@@ -27,43 +40,94 @@ module QuirkyApi
         @_finalize_adapters = []
       end
 
+      # This method executes all configured adapters' call methods in order to
+      # manipulate the response data.  By calling everything in order, we get
+      # the final response.
       def call!
+        # Get all adapters, inclusive of the ones listed above, and iterate
+        # over them.
         configured_adapters.each do |adapter|
+          # Instantiate a new instance of the adapter given the current data.
           a = adapter.new(@data, options)
+
+          # If this particular adapter has a +finalize+ method (see below),
+          # keep a record of its existence so we can call it later.
           @_finalize_adapters << adapter if a.respond_to?(:finalize)
+
+          # Call the +call+ method in order to manipulate the response.
           @data = a.call
         end
 
+        # Return the final response.
         @data
       end
 
+      # finalize! is called after the response data has been manipulated,
+      # before we actually call +render json: ...+ on it.  This method calls
+      # the +finalize+ method on any adapter that has it (as determined above),
+      # which in turn allows you to change things like response status, JSONP
+      # callbacks, and so forth.
+      #
+      # Note: Your custom +finalize+ implementation must accept the
+      # +renderable+ argument and return a Ruby Hash that the +render+ method
+      # can understand.
+      #
+      # @param [Hash] The current object that will be called by +render+ when
+      #               all is said and done.
+      #
       def finalize!(renderable)
+        # As determined above, get all adapters that implement a +finalize+
+        # method and iterate over those adapters.
         @_finalize_adapters.each do |adapter|
+          # Instantiate a new instance.  We do this to ensure that we
+          # definitely have the latest data / options following data
+          # manipulation by the +call!+ method.
           a = adapter.new(data, options)
+
+          # Call +finalize+ on the adapter and set +renderable+ to its
+          # response.
           renderable = a.finalize(renderable)
         end
 
+        # Return the very final response object.  Just after this is called,
+        # we call +render+ with this value.
         renderable
       end
 
       private
 
+      # Retrieves all adapters, homegrown and custom, that will be used to
+      # manipulate our response.
       def configured_adapters
+        # Get our adapters as above.
         adapters = ADAPTERS.dup
 
+        # Get all configured custom adapters and iterate over them.
         QuirkyApi.adapters.all.each do |configured_adapter|
-          case configured_adapter[:operation]
+          # Get the index of the adapter that will be used to determine
+          # placement on the custom adapter.
+          index = adapters.index(configured_adapter[:adapter])
+
+          # Get the pre-existing adapter at that index.
+          old_adapter = adapters[index]
+
+          # Determine the placement of the new adapter by the 'placement'
+          # specified when you configured it (based upon insert_before/after).
+          # '+1' here means the new adapter should go after the old one, '-1'
+          # means it should go before the old one.
+          case configured_adapter[:placement]
+          # Append
           when '+1'
-            index = adapters.index(configured_adapter[:position])
-            old_thing = adapters[index]
-            adapters[index, 1] = [old_thing, configured_adapter[:adapter]]
+            # Put the new adapter immediately after the old adapter.
+            adapters[index, 1] = [old_adapter, configured_adapter[:new_adapter]]
+          # Prepend
           when '-1'
-            index = adapters.index(configured_adapter[:position])
-            old_thing = adapters[index]
-            adapters[index, 1] = [configured_adapter[:adapter], old_thing]
+            # Put the ne wadapter immediately before the old adapter.
+            adapters[index, 1] = [configured_adapter[:new_adapter], old_adapter]
           end
         end
 
+        # Return all adapters such as they are.
         adapters
       end
     end


### PR DESCRIPTION
By using adapters, we get more flexibility in how we return the data in the API and open up more possibilities for further API development.
- Breaks out body manipulation (`append_meta` method) and JSON response (`prepare_json_response` method) logic into several adapters (that run in the following order):
  - `JsonpAdapter` adds (optional) JSONP support to the API response.
  - `EnvelopeAdapter` wraps content in the configured envelope (e.g., `"test"` becomes `{data: "test" }`).
  - `WarningsAdapter` optionally shows potential warnings due to invalid request fields.
  - `ElementsAdapter` adds top-level keys to the response.
  - `PaginatedMetaAdapter` returns meta from our custom pagination implementation.
  - `PrettyPrintAdapter` optionally "prettifies" the response.
- Custom adapters may be easily created and configured for api response manipulation.  See below for more details.
- Adds adapters configuration to `Configurable`.
- Cleans up `Response` module and makes slight tweaks in order to accommodate new structure.
